### PR TITLE
Added new vscode extension: Remote-WSL

### DIFF
--- a/vscode-extensions.md
+++ b/vscode-extensions.md
@@ -60,3 +60,4 @@ Extension | Description
 [Auto Import](https://marketplace.visualstudio.com/items?itemName=steoates.autoimport) | Automatically finds, parses and provides code actions and code completion for all available imports. Works with Typescript and TSX.
 [Aural Coding (Keyboard sounds)](https://marketplace.visualstudio.com/items?itemName=jeng.aural-coding-vscode) | A Visual Studio Code extension that creates sweet melodies based on what you type.
 [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | An extension that integrates ESLint into VS Code.
+[Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) | Open any folder in the Windows Subsystem for Linux (WSL) and take advantage of Visual Studio Code's full feature set.


### PR DESCRIPTION
Remote-WSL has been added to vscode-extensions.md. The Remote - WSL extension lets you use VS Code on Windows to build Linux applications that run on the Windows Subsystem for Linux (WSL). You get all the productivity of Windows while developing with Linux-based tools, runtimes, and utilities.