### PR TITLE
Add intellij idea keybindings to the list

### DIFF
--- a/vscode-extensions.md
+++ b/vscode-extensions.md
@@ -103,4 +103,5 @@
 [HTML Boilerplate](https://marketplace.visualstudio.com/items?itemName=sidthesloth.html5-boilerplate) | Provides the standard HTML boilerplate used in all web applications.
 [Auto Rename Tag](https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-rename-tag) | Automatically rename paired HTML/XML tag, same as Visual Studio IDE does.
 [Intellij Idea Keybindings](https://marketplace.visualstudio.com/items?itemName=k--kato.intellij-idea-keybindings) | For those who once were used to use Intellij or other tools from Jetbrains, this plugin allow you to include the keymaps for popular JetBrains products like IntelliJ Ultimate, WebStorm, PyCharm, PHP Storm, etc.
+[Solargraph](https://github.com/castwide/vscode-solargraph) | Solargraph is a language server that provides intellisense, code completion, and inline documentation for Ruby.
 

--- a/vscode-extensions.md
+++ b/vscode-extensions.md
@@ -102,4 +102,5 @@
 [Code Time](https://marketplace.visualstudio.com/items?itemName=softwaredotcom.swdc-vscode) | Code Time is an open source plugin for automatic programming metrics and time tracking.
 [HTML Boilerplate](https://marketplace.visualstudio.com/items?itemName=sidthesloth.html5-boilerplate) | Provides the standard HTML boilerplate used in all web applications.
 [Auto Rename Tag](https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-rename-tag) | Automatically rename paired HTML/XML tag, same as Visual Studio IDE does.
+[Intellij Idea Keybindings](https://marketplace.visualstudio.com/items?itemName=k--kato.intellij-idea-keybindings) | For those who once were used to use Intellij or other tools from Jetbrains, this plugin allow you to include the keymaps for popular JetBrains products like IntelliJ Ultimate, WebStorm, PyCharm, PHP Storm, etc.
 


### PR DESCRIPTION
I was used to use the Intellij to code and this plugin really can help people that want to be more productive keeping the shortcuts used in this tool, but in VSCode.