### PR TITLE
Added Explainshell

### DIFF
--- a/web-tools.md
+++ b/web-tools.md
@@ -168,3 +168,4 @@
 [Write PHP Online](http://www.writephponline.com/) | Simple free website that allows you to execute PHP code.
 [XML Viewer](https://codebeautify.org/xmlviewer#) | Beautify XML files
 [You might not need jQuery](https://youmightnotneedjquery.com/) | Provides a list of jQuery commands in Vanilla JS.
+[Explainshell](https://explainshell.com/) | Parsing man pages, extracting options, and matching each argument to the relevant help text in the man page to explain a given command line.


### PR DESCRIPTION
Explainshell is a web-based application for parsing man pages, extracting options, and matching each argument to the relevant help text in the man page to explain a given command line.